### PR TITLE
Feat: Allow transient database usage for cases where OPFS is not available

### DIFF
--- a/src/database/database.ts
+++ b/src/database/database.ts
@@ -3,11 +3,20 @@ import { MessageType, SqliteClientFunction } from "../types/sqlite.promiser";
 
 async function openDB(sqlite: SqliteClientFunction): Promise<void> {
   console.info("Opening main database");
-  await sqlite(MessageType.Open, { filename: MAIN_THIBI_DB, vfs: "opfs" }).then(
-    () => {
-      console.info("Database successfully opened and connected");
-    },
-  );
+  try {
+    await sqlite(MessageType.Open, {
+      filename: MAIN_THIBI_DB,
+      vfs: "opfs",
+    }).then(() => {
+      console.info("Persistent database successfully opened and connected");
+    });
+  } catch (err: unknown) {
+    await sqlite(MessageType.Open, { filename: MAIN_THIBI_DB }).then(() => {
+      console.info(
+        "Transient (in-memory) database successfully opened and connected",
+      );
+    });
+  }
 }
 
 async function initJobsTable(sqlite: SqliteClientFunction): Promise<void> {
@@ -22,7 +31,7 @@ async function initJobsTable(sqlite: SqliteClientFunction): Promise<void> {
 }
 
 async function initDB(sqlite: SqliteClientFunction): Promise<void> {
-  console.info("Initializing database using `opfs`");
+  console.info("Initializing database");
   await openDB(sqlite);
   await initJobsTable(sqlite);
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,26 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Credit: https://github.com/vitejs/vite/issues/9864#issuecomment-1230560351
-const previewServerPlugin = {
-  name: "preview-server-headers-plugin",
-  configurePreviewServer(server) {
-    server.middlewares.use((req, res, next) => {
-      res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
-      res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
-      res.setHeader("Service-Worker-Allowed", "/"); // I do this because I want my worker to work everywhere on my site, but I want to organize it my way.
-      next();
-    });
-  },
-};
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), previewServerPlugin],
+  plugins: [react()],
   server: {
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "require-corp",
       "Service-Worker-Allowed": "/",
+    },
+  },
+  preview: {
+    headers: {
+      "Cross-Origin-Opener-Policy": "same-origin",
+      "Cross-Origin-Embedder-Policy": "require-corp",
+      "Service-Worker-Allowed": "/", // I do this because I want my worker to work everywhere on my site, but I want to organize it my way.
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
This PR:
* Allows using in-memory, transient database as a fallback when OPFS is not available.

As part of #4 , we should also make it clear whether a transient or persistent database is in use.